### PR TITLE
Persist to workspace to make architect deploy work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,11 @@ jobs:
         chmod +x ./architect
         ./architect version
     - run: ./architect build
+    - persist_to_workspace:
+        root: .
+        paths:
+          - ./release-operator
+          - ./architect
 
   e2eTestBasic:
     environment:


### PR DESCRIPTION
Merging into master currently fails because we do not persist architect to workspace like we do in other projects (e.g. chart-operator).

See https://circleci.com/workflow-run/07646e13-0f6c-46f8-833a-cac60d68dd5c
