### PR TITLE
Register Release CRD

### DIFF
--- a/service/controller/release.go
+++ b/service/controller/release.go
@@ -1,20 +1,24 @@
 package controller
 
 import (
+	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/client/k8scrdclient"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/informer"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/release-operator/service/controller/v1"
 )
 
 type ReleaseConfig struct {
-	G8sClient versioned.Interface
-	K8sClient kubernetes.Interface
-	Logger    micrologger.Logger
+	G8sClient    versioned.Interface
+	K8sClient    kubernetes.Interface
+	K8sExtClient apiextensionsclient.Interface
+	Logger       micrologger.Logger
 
 	ProjectName string
 }
@@ -29,6 +33,19 @@ func NewRelease(config ReleaseConfig) (*Release, error) {
 	}
 
 	var err error
+
+	var crdClient *k8scrdclient.CRDClient
+	{
+		c := k8scrdclient.Config{
+			K8sExtClient: config.K8sExtClient,
+			Logger:       config.Logger,
+		}
+
+		crdClient, err = k8scrdclient.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
 
 	var newInformer *informer.Informer
 	{
@@ -64,8 +81,10 @@ func NewRelease(config ReleaseConfig) (*Release, error) {
 	var releaseController *controller.Controller
 	{
 		c := controller.Config{
-			Informer: newInformer,
-			Logger:   config.Logger,
+			CRD:       v1alpha1.NewReleaseCRD(),
+			CRDClient: crdClient,
+			Informer:  newInformer,
+			Logger:    config.Logger,
 			ResourceSets: []*controller.ResourceSet{
 				v1ResourceSet,
 			},

--- a/service/service.go
+++ b/service/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/client/k8srestconfig"
 	"github.com/spf13/viper"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -84,6 +85,11 @@ func New(config Config) (*Service, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	k8sExtClient, err := apiextensionsclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	var versionService *version.Service
 	{
 		versionConfig := version.Config{
@@ -103,9 +109,10 @@ func New(config Config) (*Service, error) {
 	var releaseController *controller.Release
 	{
 		c := controller.ReleaseConfig{
-			Logger:    config.Logger,
-			G8sClient: g8sClient,
-			K8sClient: k8sClient,
+			Logger:       config.Logger,
+			G8sClient:    g8sClient,
+			K8sClient:    k8sClient,
+			K8sExtClient: k8sExtClient,
 
 			ProjectName: config.ProjectName,
 		}


### PR DESCRIPTION
Release CRD registration was missing and therefore it wasn't present in
installations despite of release-operator being deployed everywhere.