### PR TITLE
Use g8s rest client when working with g8s apiextension CRs

### DIFF
--- a/service/controller/release.go
+++ b/service/controller/release.go
@@ -88,7 +88,7 @@ func NewRelease(config ReleaseConfig) (*Release, error) {
 			ResourceSets: []*controller.ResourceSet{
 				v1ResourceSet,
 			},
-			RESTClient: config.K8sClient.CoreV1().RESTClient(),
+			RESTClient: config.G8sClient.CoreV1alpha1().RESTClient(),
 
 			Name: config.ProjectName,
 		}


### PR DESCRIPTION
Due to encoding magic in client-go, one must use correct rest client.