### PR TITLE
app: extract newAppCRToUpdate to a separate file

### DIFF
--- a/pkg/controller/resource/app/new_app_cr_to_update.go
+++ b/pkg/controller/resource/app/new_app_cr_to_update.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"reflect"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+)
+
+// newAppCRToUpdate creates a new instance of App CR ready to be used as an
+// argument to Update method of generated client. It returns nil if the name or
+// namespace doesn't match or if objects don't have differences in scope of
+// interest.
+func newAppCRToUpdate(current, desired *v1alpha1.App) *v1alpha1.App {
+	if current.Namespace != desired.Namespace {
+		return nil
+	}
+	if current.Name != desired.Name {
+		return nil
+	}
+
+	merged := current.DeepCopy()
+
+	merged.Annotations = desired.Annotations
+	merged.Labels = desired.Labels
+
+	merged.Spec = desired.Spec
+
+	if reflect.DeepEqual(current, merged) {
+		return nil
+	}
+
+	return merged
+}

--- a/pkg/controller/resource/app/update.go
+++ b/pkg/controller/resource/app/update.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
@@ -59,26 +58,4 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 	}
 
 	return appCRsToUpdate, nil
-}
-
-func newAppCRToUpdate(current, desired *v1alpha1.App) *v1alpha1.App {
-	if current.Namespace != desired.Namespace {
-		return nil
-	}
-	if current.Name != desired.Name {
-		return nil
-	}
-
-	merged := current.DeepCopy()
-
-	merged.Annotations = desired.Annotations
-	merged.Labels = desired.Labels
-
-	merged.Spec = desired.Spec
-
-	if reflect.DeepEqual(current, merged) {
-		return nil
-	}
-
-	return merged
 }


### PR DESCRIPTION
This function will be the only real difference between reusable
resources. Other stuff is just a copy paste + replacements. Something we
can potentially generate. newOjbectTypeToUpdate will be custom for each
object and needs different testing. I'd like to extract it to make it
easier to create and review new resources.

Creating a resource would boil down to those three tasks:

1. Copy one of existing generic resources.
2. Update imports and log messages. E.g. s/App CR/ConfigMap/,
   s/appCR/configMap/, etc.
3. Replace newAppCRToUpdate with newConfigMapToUpdate (this is the only
   place where semantic has to be changed).