### PR TITLE
flag, main, service: remove app-catalog flag

### DIFF
--- a/flag/flag.go
+++ b/flag/flag.go
@@ -3,13 +3,11 @@ package flag
 import (
 	"github.com/giantswarm/microkit/flag"
 
-	"github.com/giantswarm/release-operator/flag/release"
 	"github.com/giantswarm/release-operator/flag/service"
 )
 
 // Flag provides data structure for service command line flags.
 type Flag struct {
-	Release release.Release
 	Service service.Service
 }
 

--- a/flag/release/release.go
+++ b/flag/release/release.go
@@ -1,6 +1,0 @@
-package release
-
-// Release is an intermediate data structure for command line configuration flags.
-type Release struct {
-	AppCatalog string
-}

--- a/main.go
+++ b/main.go
@@ -95,7 +95,6 @@ func mainWithError() (err error) {
 
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
-	daemonCommand.PersistentFlags().String(f.Release.AppCatalog, "control-plane", "application catalog name. Used to install releases.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, true, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.KubeConfig, "", "KubeConfig used to connect to Kubernetes. When empty other settings are used.")

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -10,6 +10,10 @@ import (
 )
 
 const (
+	// AppCatalog is the name of the app catalog where releases and release
+	// components are stored.
+	AppCatalog = "control-plane"
+
 	// Namespace is the namespace where App CRs are created.
 	Namespace = "giantswarm"
 

--- a/service/controller/release.go
+++ b/service/controller/release.go
@@ -26,8 +26,6 @@ type ReleaseConfig struct {
 	K8sClient    kubernetes.Interface
 	K8sExtClient apiextensionsclient.Interface
 	Logger       micrologger.Logger
-
-	AppCatalog string
 }
 
 type Release struct {
@@ -76,8 +74,6 @@ func NewRelease(config ReleaseConfig) (*Release, error) {
 			G8sClient: config.G8sClient,
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
-
-			AppCatalog: config.AppCatalog,
 		}
 
 		resourceSet, err = release.NewResourceSet(c)

--- a/service/controller/release/resource/app/desired.go
+++ b/service/controller/release/resource/app/desired.go
@@ -37,7 +37,7 @@ func (r *resourceStateGetter) GetDesiredState(ctx context.Context, obj interface
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computing desired app CRs for release %#q components", cr.Name))
 
 		for _, c := range desiredComponents {
-			appCR := newAppCR(appCRName(c), c.Name, c.Version, r.appCatalog)
+			appCR := newAppCR(appCRName(c), c.Name, c.Version, key.AppCatalog)
 			desiredAppCRs = append(desiredAppCRs, appCR)
 		}
 

--- a/service/controller/release/resource/app/desired_test.go
+++ b/service/controller/release/resource/app/desired_test.go
@@ -265,8 +265,6 @@ func Test_resourceStateGetter_getDesiredComponents(t *testing.T) {
 				stateGetter = &resourceStateGetter{
 					g8sClient: fakeG8sClient,
 					logger:    microloggertest.New(),
-
-					appCatalog: "test-app-catalog",
 				}
 			}
 

--- a/service/controller/release/resource/app/resource.go
+++ b/service/controller/release/resource/app/resource.go
@@ -17,8 +17,6 @@ const (
 type Config struct {
 	G8sClient versioned.Interface
 	Logger    micrologger.Logger
-
-	AppCatalog string
 }
 
 // New returns a resource creating/updating App CRs for components in non-EOL
@@ -33,17 +31,11 @@ func New(config Config) (controller.Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	if config.AppCatalog == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.AppCatalog must not be empty", config)
-	}
-
 	var err error
 
 	stateGetter := &resourceStateGetter{
 		g8sClient: config.G8sClient,
 		logger:    config.Logger,
-
-		appCatalog: config.AppCatalog,
 	}
 
 	var appResource *app.Resource

--- a/service/controller/release/resource/app/resource_state_getter.go
+++ b/service/controller/release/resource/app/resource_state_getter.go
@@ -8,6 +8,4 @@ import (
 type resourceStateGetter struct {
 	g8sClient versioned.Interface
 	logger    micrologger.Logger
-
-	appCatalog string
 }

--- a/service/controller/release/resource_set.go
+++ b/service/controller/release/resource_set.go
@@ -21,8 +21,6 @@ type ResourceSetConfig struct {
 	G8sClient versioned.Interface
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
-
-	AppCatalog string
 }
 
 func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
@@ -60,8 +58,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := app.Config{
 			G8sClient: config.G8sClient,
 			Logger:    config.Logger,
-
-			AppCatalog: config.AppCatalog,
 		}
 
 		appResource, err = app.New(c)

--- a/service/service.go
+++ b/service/service.go
@@ -111,8 +111,6 @@ func New(config Config) (*Service, error) {
 			G8sClient:    g8sClient,
 			K8sClient:    k8sClient,
 			K8sExtClient: k8sExtClient,
-
-			AppCatalog: config.Viper.GetString(config.Flag.Release.AppCatalog),
 		}
 
 		releaseController, err = controller.NewRelease(c)
@@ -128,8 +126,6 @@ func New(config Config) (*Service, error) {
 			G8sClient:    g8sClient,
 			K8sClient:    k8sClient,
 			K8sExtClient: k8sExtClient,
-
-			AppCatalog: config.Viper.GetString(config.Flag.Release.AppCatalog),
 		}
 
 		releaseCycleController, err = controller.NewReleaseCycle(c)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5278.

Already agreed with @TheoBrigitte. This blocks me with e2e testing and
I don't want to waste time on extending templates.

Having that configurable makes little sense at the current stage and
only introduces clutter. This is questionable if we'll need to configure
that ever.

Note this value will have to be dynamic in the future because
release-operator has to switch between control-plane and
control-plane-test app catalogs. But this will be implemented later. And
it's bit cleaner to achieve in the key package.