### PR TITLE
e2e: test eol release

### DIFF
--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -369,7 +369,7 @@ func TestReleaseHandling(t *testing.T) {
 
 	// Verifies that components App CRs are gone.
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking if App CR were removed", releaseCR.Name))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking if App CR were removed")
 
 		o := func() error {
 			list, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps("").List(metav1.ListOptions{})
@@ -398,6 +398,6 @@ func TestReleaseHandling(t *testing.T) {
 			t.Fatalf("err == %v, want %v", err, nil)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked if App CR were removed", releaseCR.Name))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "checked if App CR were removed")
 	}
 }

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -279,8 +279,7 @@ func TestReleaseHandling(t *testing.T) {
 
 	// Mark the release as enabled by creating a release cycle with phase=enabled.
 	{
-		var err error
-		releaseCycleCR, err = config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Create(releaseCycleCR)
+		_, err := config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Create(releaseCycleCR)
 		if err != nil {
 			t.Fatalf("err == %v, want %v", err, nil)
 		}
@@ -328,12 +327,16 @@ func TestReleaseHandling(t *testing.T) {
 
 	// Update the release to eol by updating the release cycle with phase=eol.
 	{
-		c := releaseCycleCR.DeepCopy()
+		c, err := config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Get(releaseCycleCR.GetName(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("err == %v, want %v", err, nil)
+		}
+
 		c.Spec.Phase = releasev1alpha1.CyclePhaseEOL
 		c.Spec.DisabledDate = releasev1alpha1.DeepCopyDate{time.Date(2019, 4, 8, 0, 0, 0, 0, time.UTC)}
 		c.Spec.EnabledDate = releasev1alpha1.DeepCopyDate{time.Date(2019, 1, 8, 0, 0, 0, 0, time.UTC)}
 
-		_, err := config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Update(c)
+		_, err = config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Update(c)
 		if err != nil {
 			t.Fatalf("err == %v, want %v", err, nil)
 		}

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -382,7 +382,7 @@ func TestReleaseHandling(t *testing.T) {
 		}
 	}
 
-	// Verifies there is no App CRs.
+	// Verifies that components App CRs are gone.
 	{
 		o := func() error {
 			list, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps("").List(metav1.ListOptions{})
@@ -390,8 +390,16 @@ func TestReleaseHandling(t *testing.T) {
 				return microerror.Mask(err)
 			}
 
-			if len(list.Items) > 0 {
-				return microerror.Maskf(waitError, "%d Apps found, want %d", len(list.Items), 0)
+			expectedAppCRNames := []string{
+				"aws-operator.4.6.0",
+				"cert-operator.0.1.0",
+			}
+			for _, obj := range list.Items {
+				for _, name := range expectedAppCRNames {
+					if obj.GetName() == name {
+						return microerror.Maskf(waitError, "not expected to found App CR %s", obj.GetName())
+					}
+				}
 			}
 
 			return nil

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -285,7 +285,7 @@ func TestReleaseHandling(t *testing.T) {
 		}
 	}
 
-	// Verify that release status was reconciled from release cycle.
+	// Verify that release was reconciled, status and label should be updated with values from release cycle.
 	{
 		o := func() error {
 			obj, err := config.K8sClients.G8sClient().ReleaseV1alpha1().Releases().Get(releaseCR.Name, metav1.GetOptions{})
@@ -303,6 +303,16 @@ func TestReleaseHandling(t *testing.T) {
 
 			if obj.Status.Cycle.Phase != releasev1alpha1.CyclePhaseEnabled {
 				return microerror.Maskf(waitError, "obj.Status.Cycle.Phase = %#v, want %#v", obj.Status.Cycle.Phase, releasev1alpha1.CyclePhaseUpcoming)
+			}
+
+			if obj.Labels == nil {
+				return microerror.Maskf(waitError, "obj.Labels = %#v, want non-nil", obj.Labels)
+			}
+
+			k := "release-operator.giantswarm.io/release-cycle-phase"
+			v := obj.Labels[k]
+			if v != releasev1alpha1.CyclePhaseEnabled.String() {
+				return microerror.Maskf(waitError, "obj.Labels[%q] = %q, want %q", obj.Labels[k], releasev1alpha1.CyclePhaseUpcoming.String())
 			}
 
 			return nil

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -276,4 +276,42 @@ func TestReleaseHandling(t *testing.T) {
 
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked if Release CR %#q was updated", releaseCR.Name))
 	}
+
+	// Mark the release as enabled by creating a release cycle with phase=enabled.
+	{
+		_, err := config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Create(releaseCycleCR)
+		if err != nil {
+			t.Fatalf("err == %v, want %v", err, nil)
+		}
+	}
+
+	// Verify that release status was reconciled from release cycle.
+	{
+		o := func() error {
+			obj, err := config.K8sClients.G8sClient().ReleaseV1alpha1().Releases().Get(releaseCR.Name, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			if !obj.Status.Cycle.DisabledDate.Equal(time.Date(2019, 1, 12, 0, 0, 0, 0, time.UTC)) {
+				return microerror.Maskf(waitError, "obj.Status.Cycle.DisabledDate = %s, want %s", obj.Status.Cycle.DisabledDate, time.Date(2019, 1, 12, 0, 0, 0, 0, time.UTC))
+			}
+
+			if !obj.Status.Cycle.EnabledDate.Equal(time.Date(2019, 1, 8, 0, 0, 0, 0, time.UTC)) {
+				return microerror.Maskf(waitError, "obj.Status.Cycle.EnabledDate = %s, want %s", obj.Status.Cycle.EnabledDate, time.Date(2019, 1, 8, 0, 0, 0, 0, time.UTC))
+			}
+
+			if obj.Status.Cycle.Phase != releasev1alpha1.CyclePhaseEnabled {
+				return microerror.Maskf(waitError, "obj.Status.Cycle.Phase = %#v, want %#v", obj.Status.Cycle.Phase, releasev1alpha1.CyclePhaseUpcoming)
+			}
+
+			return nil
+		}
+		b := backoff.NewMaxRetries(150, 1*time.Second)
+
+		err := backoff.Retry(o, b)
+		if err != nil {
+			t.Fatalf("err == %v, want %v", err, nil)
+		}
+	}
 }

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -391,7 +391,7 @@ func TestReleaseHandling(t *testing.T) {
 
 			return nil
 		}
-		b := backoff.NewMaxRetries(30, 5*time.Second)
+		b := backoff.NewMaxRetries(65, 6*time.Second)
 
 		err := backoff.Retry(o, b)
 		if err != nil {

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -359,6 +359,8 @@ func TestReleaseHandling(t *testing.T) {
 
 	// Verify that release was reconciled, status should be updated with values from release cycle.
 	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking if Release CR status %#q was updated", releaseCR.Name))
+
 		o := func() error {
 			obj, err := config.K8sClients.G8sClient().ReleaseV1alpha1().Releases().Get(releaseCR.Name, metav1.GetOptions{})
 			if err != nil {
@@ -387,10 +389,14 @@ func TestReleaseHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err == %v, want %v", err, nil)
 		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked if Release CR status %#q was updated", releaseCR.Name))
 	}
 
 	// Verify that release was reconciled, label should be updated with values from release cycle.
 	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking if Release CR labels %#q were updated", releaseCR.Name))
+
 		o := func() error {
 			obj, err := config.K8sClients.G8sClient().ReleaseV1alpha1().Releases().Get(releaseCR.Name, metav1.GetOptions{})
 			if err != nil {
@@ -415,10 +421,14 @@ func TestReleaseHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err == %v, want %v", err, nil)
 		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked if Release CR labels %#q were updated", releaseCR.Name))
 	}
 
 	// Verifies that components App CRs are gone.
 	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking if App CR were removed", releaseCR.Name))
+
 		o := func() error {
 			list, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps("").List(metav1.ListOptions{})
 			if err != nil {
@@ -445,5 +455,7 @@ func TestReleaseHandling(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err == %v, want %v", err, nil)
 		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked if App CR were removed", releaseCR.Name))
 	}
 }

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -323,16 +323,6 @@ func TestReleaseHandling(t *testing.T) {
 				return microerror.Maskf(waitError, "\n\n%s\nobj.Status.Cycle = %#v\nreleaseCycleCREOL.Spec = %#v\n\n", cmp.Diff(obj.Status.Cycle, releaseCycleCREOL.Spec), obj.Status.Cycle, releaseCycleCREOL.Spec)
 			}
 
-			if obj.Labels == nil {
-				return microerror.Maskf(waitError, "obj.Labels = %#v, want non-nil", obj.Labels)
-			}
-
-			k := "release-operator.giantswarm.io/release-cycle-phase"
-			v := obj.Labels[k]
-			if v != releasev1alpha1.CyclePhaseEOL.String() {
-				return microerror.Maskf(waitError, "obj.Labels[%q] = %q, want %q", obj.Labels[k], releasev1alpha1.CyclePhaseEOL.String())
-			}
-
 			return nil
 		}
 		b := backoff.NewMaxRetries(150, 1*time.Second)

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -279,7 +279,8 @@ func TestReleaseHandling(t *testing.T) {
 
 	// Mark the release as enabled by creating a release cycle with phase=enabled.
 	{
-		_, err := config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Create(releaseCycleCR)
+		var err error
+		releaseCycleCR, err = config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Create(releaseCycleCR)
 		if err != nil {
 			t.Fatalf("err == %v, want %v", err, nil)
 		}
@@ -318,6 +319,81 @@ func TestReleaseHandling(t *testing.T) {
 			return nil
 		}
 		b := backoff.NewMaxRetries(150, 1*time.Second)
+
+		err := backoff.Retry(o, b)
+		if err != nil {
+			t.Fatalf("err == %v, want %v", err, nil)
+		}
+	}
+
+	// Update the release to eol by updating the release cycle with phase=eol.
+	{
+		c := releaseCycleCR.DeepCopy()
+		c.Spec.Phase = releasev1alpha1.CyclePhaseEOL
+		c.Spec.DisabledDate = releasev1alpha1.DeepCopyDate{time.Date(2019, 4, 8, 0, 0, 0, 0, time.UTC)}
+		c.Spec.EnabledDate = releasev1alpha1.DeepCopyDate{time.Date(2019, 1, 8, 0, 0, 0, 0, time.UTC)}
+
+		_, err := config.K8sClients.G8sClient().ReleaseV1alpha1().ReleaseCycles().Update(c)
+		if err != nil {
+			t.Fatalf("err == %v, want %v", err, nil)
+		}
+	}
+
+	// Verify that release was reconciled, status and label should be updated with values from release cycle.
+	{
+		o := func() error {
+			obj, err := config.K8sClients.G8sClient().ReleaseV1alpha1().Releases().Get(releaseCR.Name, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			if !obj.Status.Cycle.DisabledDate.Equal(time.Date(2019, 4, 8, 0, 0, 0, 0, time.UTC)) {
+				return microerror.Maskf(waitError, "obj.Status.Cycle.DisabledDate = %s, want %s", obj.Status.Cycle.DisabledDate, time.Date(2019, 4, 8, 0, 0, 0, 0, time.UTC))
+			}
+
+			if !obj.Status.Cycle.EnabledDate.Equal(time.Date(2019, 1, 8, 0, 0, 0, 0, time.UTC)) {
+				return microerror.Maskf(waitError, "obj.Status.Cycle.EnabledDate = %s, want %s", obj.Status.Cycle.EnabledDate, time.Date(2019, 1, 8, 0, 0, 0, 0, time.UTC))
+			}
+
+			if obj.Status.Cycle.Phase != releasev1alpha1.CyclePhaseEOL {
+				return microerror.Maskf(waitError, "obj.Status.Cycle.Phase = %#v, want %#v", obj.Status.Cycle.Phase, releasev1alpha1.CyclePhaseEOL)
+			}
+
+			if obj.Labels == nil {
+				return microerror.Maskf(waitError, "obj.Labels = %#v, want non-nil", obj.Labels)
+			}
+
+			k := "release-operator.giantswarm.io/release-cycle-phase"
+			v := obj.Labels[k]
+			if v != releasev1alpha1.CyclePhaseEOL.String() {
+				return microerror.Maskf(waitError, "obj.Labels[%q] = %q, want %q", obj.Labels[k], releasev1alpha1.CyclePhaseEOL.String())
+			}
+
+			return nil
+		}
+		b := backoff.NewMaxRetries(150, 1*time.Second)
+
+		err := backoff.Retry(o, b)
+		if err != nil {
+			t.Fatalf("err == %v, want %v", err, nil)
+		}
+	}
+
+	// Verifies there is no App CRs.
+	{
+		o := func() error {
+			list, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps("").List(metav1.ListOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			if len(list.Items) > 0 {
+				return microerror.Maskf(waitError, "%d Apps found, want %d", len(list.Items), 0)
+			}
+
+			return nil
+		}
+		b := backoff.NewMaxRetries(30, 5*time.Second)
 
 		err := backoff.Retry(o, b)
 		if err != nil {

--- a/integration/test/releasehandling/release_handling_test.go
+++ b/integration/test/releasehandling/release_handling_test.go
@@ -384,7 +384,7 @@ func TestReleaseHandling(t *testing.T) {
 			for _, obj := range list.Items {
 				for _, name := range expectedAppCRNames {
 					if obj.GetName() == name {
-						return microerror.Maskf(waitError, "not expected to found App CR %s", obj.GetName())
+						return microerror.Maskf(waitError, "not expected to find App CR %s", obj.GetName())
 					}
 				}
 			}


### PR DESCRIPTION
Towards: giantswarm/giantswarm#5278

Mark a release as end-of-life, and verifies that every components app CRs are deleted.