### PR TITLE
Disable flapping release handling e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,10 @@ workflows:
       - e2eTestBasic:
           requires:
           - build
-      - e2eTestMultiReleaseHandling:
-          requires:
-          - build
-# TODO reenable and fix this flapping e2e integration test
+# TODO reenable and fix these flapping e2e integration tests
+#      - e2eTestMultiReleaseHandling:
+#          requires:
+#          - build
 #      - e2eTestReleaseHandling:
 #          requires:
 #          - build
@@ -103,6 +103,6 @@ workflows:
               only: master
           requires:
           - e2eTestBasic
-          - e2eTestMultiReleaseHandling
+#          - e2eTestMultiReleaseHandling
 #          - e2eTestReleaseHandling
           - e2eTestReleaseCycle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,10 @@ workflows:
       - e2eTestMultiReleaseHandling:
           requires:
           - build
-      - e2eTestReleaseHandling:
-          requires:
-          - build
+# TODO reenable and fix this flapping e2e integration test
+#      - e2eTestReleaseHandling:
+#          requires:
+#          - build
       - e2eTestReleaseCycle:
           requires:
           - build
@@ -103,5 +104,5 @@ workflows:
           requires:
           - e2eTestBasic
           - e2eTestMultiReleaseHandling
-          - e2eTestReleaseHandling
+#          - e2eTestReleaseHandling
           - e2eTestReleaseCycle


### PR DESCRIPTION
Release handling e2e test are flapping and preventing the rollouts (see related discussion on Slack https://gigantic.slack.com/archives/C3C7ZQXC1/p1576231447323800).
We decided to disable them until we find time to fix them.

TODO for eventually getting these tests fixed https://github.com/giantswarm/giantswarm/issues/8096