### PR TITLE
circleci, helm: go back to no-orb  deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [Unreleased]: https://github.com/giantswarm/release-operator/compare/v0.2.2...HEAD
-
 [0.2.2]: https://github.com/giantswarm/release-operator/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/giantswarm/release-operator/compare/v0.2.0...v0.2.1
-
 [0.2.0]: https://github.com/giantswarm/release-operator/releases/tag/v0.2.0

--- a/helm/release-operator/values.yaml
+++ b/helm/release-operator/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: "giantswarm/release-operator"
-  tag: "[[ .Version ]]"
+  tag: "[[ .SHA ]]"
 Installation:
   V1:
     Registry:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9040.

This reverts commit edff4f33eb70d52b5f4b9543f5b7c22b971a8839.
This reverts commit dd08035be2e235c0e9dd003092b24654892765aa.

## Checklist

- [x] Update changelog in CHANGELOG.md.