### PR TITLE
circleci: push to aliyun always

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,37 +59,13 @@ workflows:
           requires:
             - build
 
-      - hold-push-release-operator-to-aliyun-pr:
-          type: approval
-          requires:
-            - build
-          # Needed to prevent job from being triggered on master branch.
-          filters:
-            branches:
-              ignore: master
-
       - architect/push-to-docker-legacy:
-          name: push-release-operator-to-aliyun-pr
-          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/release-operator"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          # Push to Aliyun should execute for non-master branches only once manually approved.
-          requires:
-            - hold-push-release-operator-to-aliyun-pr
-          # Needed to prevent job being triggered for master branch.
-          filters:
-            branches:
-              ignore: master
-
-      # Push to Aliyun should execute without manual approval on master.
-      - architect/push-to-docker-legacy:
-          name: push-release-operator-to-aliyun-master
+          name: push-release-operator-to-aliyun
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/release-operator"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
           requires:
             - build
-          # Needed to trigger job only on merge to master.
           filters:
             branches:
               only: master
@@ -99,5 +75,5 @@ workflows:
             branches:
               only: master
           requires:
-          - push-release-operator-to-aliyun-master
+          - push-release-operator-to-aliyun
           - push-release-operator-to-quay


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9040

I notice this is a new trend. At least in aws-operator which is SOTA.

I want to have the circle config clean before I start with moving to collection based deployment.

## Checklist

- [x] Update changelog in CHANGELOG.md.