### PR TITLE
Don't error when deleting app if it's not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 
 - Updated backward incompatible Kubernetes dependencies to v1.18.5.
+- Don't error when app was not found while deleting app.
 
 ## [2.0.0] - 2020-07-23
 

--- a/service/controller/release/resource/apps/resource.go
+++ b/service/controller/release/resource/apps/resource.go
@@ -93,7 +93,9 @@ func (r *Resource) ensureState(ctx context.Context) error {
 			ctx,
 			&app,
 		)
-		if err != nil {
+		if apierrors.IsNotFound(err) {
+			// fall through.
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 


### PR DESCRIPTION
While redeploying my app I saw this error
```
W 09/08 10:29:34 /apis/release.giantswarm.io/v1alpha1/releases/v12.1.0-jose apps retrying due to error | operatorkit/v2/pkg/resource/wrapper/retryresource/basic_resource.go:59 | controller=release-operator-release | event=update | loop=17146 | version=187109573
        /go/pkg/mod/github.com/giantswarm/operatorkit/v2@v2.0.0/pkg/resource/wrapper/retryresource/basic_resource.go:52
        /root/project/service/controller/release/resource/apps/create.go:12
        /root/project/service/controller/release/resource/apps/resource.go:97
        unknown: apps.application.giantswarm.io "azure-operator-5.0.0-nodepools" not found
```

So I figured it makes sense to ignore "not found" errors when trying to delete an app.

## Checklist

- [X] Update changelog in CHANGELOG.md.
