### PR TITLE
Add gitleaks workflow

### DIFF
--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,0 +1,17 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl gen workflows
+#
+name: gitleaks
+
+on: [push,pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: gitleaks-action
+      uses: zricethezav/gitleaks-action@v1.1.4


### PR DESCRIPTION
I'd like to test this behavior on `release-operator` before adding it to `devctl` in https://github.com/giantswarm/devctl/pull/100