### PR TITLE
Mark KVM release as "inUse" while draining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change `inUse` status of KVM releases to `true` when any pods remain for that release to fix an issue with draining 
+  the last cluster of a deprecated release.
+
 ## [2.1.1] - 2020-10-12
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.8.0
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
+	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 // indirect

--- a/helm/release-operator/templates/rbac.yaml
+++ b/helm/release-operator/templates/rbac.yaml
@@ -6,6 +6,12 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - "list"
+  - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions

--- a/service/controller/release/resource/status/cluster.go
+++ b/service/controller/release/resource/status/cluster.go
@@ -166,5 +166,6 @@ func (r *Resource) getLegacyKVMClusters(ctx context.Context) ([]tenantCluster, e
 		}
 		clusters = append(clusters, c)
 	}
+
 	return clusters, nil
 }

--- a/service/controller/release/resource/status/kvm.go
+++ b/service/controller/release/resource/status/kvm.go
@@ -1,0 +1,38 @@
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/release-operator/v2/service/controller/key"
+)
+
+const (
+	// from https://github.com/giantswarm/kvm-operator/blob/9dc5f0d8075731c600e2852b27e71dbc2e91015d/service/controller/key/key.go#L123
+	PodWatcherLabel = "kvm-operator.giantswarm.io/pod-watcher"
+	// from https://github.com/giantswarm/kvm-operator/blob/9dc5f0d8075731c600e2852b27e71dbc2e91015d/service/controller/key/key.go#L101
+	KVMVersionBundleVersionAnnotation = "kvm-operator.giantswarm.io/version-bundle"
+	// from https://github.com/giantswarm/kvm-operator/blob/eee64f540cae53d530628d50e54883b636d0693f/pkg/label/label.go#L17
+	KVMOperatorVersionLabel = "kvm-operator.giantswarm.io/version"
+)
+
+func (r *Resource) getKVMOperatorVersionPodsExist(ctx context.Context, operatorVersion string) (bool, error) {
+	pods, err := r.k8sClient.K8sClient().CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", PodWatcherLabel, key.ProviderOperatorKVM),
+	})
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	for _, pod := range pods.Items {
+		if pod.Annotations[KVMVersionBundleVersionAnnotation] == operatorVersion ||
+			pod.Labels[KVMOperatorVersionLabel] == operatorVersion {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
When we upgrade a cluster to a new `kvm-operator` version, the old operator is responsible for draining it (see https://github.com/giantswarm/kvm-operator/blob/master/service/controller/drainer_resource_set.go#L30-L450). release-operator deschedules operators that aren't referenced by an active release or a running cluster. In the case of an upgrade, if this is the last cluster of a deprecated release, the old operator is descheduled and can't drain the old node so it can be replaced. The solutions I can thought of would be to keep the old operator around if it's referenced by any node pod or to let the new operator take care of draining the old pod. This PR implements the first option as it seemed more straightforward than reconciling CRs owned by other operators.

Related discussion https://gigantic.slack.com/archives/CHAHY6VMF/p1604367058111900

## Checklist

- [x] Update changelog in CHANGELOG.md.
