### PR TITLE
Use right api group for AWS and Azure clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Use right api group for AWS and Azure clusters when trying to find workload clusters.
+- Search workload clusters on all namespaces.
+- Take CAPI clusters into account when counting workload clusters.
 
 ## [2.5.0] - 2021-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use right api group for AWS and Azure clusters when trying to find workload clusters.
+
 ## [2.5.0] - 2021-11-30
 
 ### Changed

--- a/helm/release-operator/templates/rbac.yaml
+++ b/helm/release-operator/templates/rbac.yaml
@@ -32,6 +32,12 @@ rules:
     verbs:
       - list
   - apiGroups:
+      - infrastructure.giantswarm.io
+    resources:
+      - awsclusters
+    verbs:
+      - list
+  - apiGroups:
       - release.giantswarm.io
     resources:
       - releases

--- a/service/controller/release/resource/status/cluster.go
+++ b/service/controller/release/resource/status/cluster.go
@@ -67,7 +67,7 @@ func (r *Resource) getCurrentTenantClusters(ctx context.Context) ([]tenantCluste
 func (r *Resource) getCurrentAWSClusters(ctx context.Context) ([]tenantCluster, error) {
 	awsClusters, err := r.listPartialObjectMetadata(ctx, metav1.GroupVersionKind{
 		Group:   "infrastructure.giantswarm.io",
-		Version: "v1alpha2",
+		Version: "v1alpha3",
 		Kind:    "AWSCluster",
 	})
 	if err != nil {

--- a/service/controller/release/resource/status/cluster.go
+++ b/service/controller/release/resource/status/cluster.go
@@ -67,7 +67,7 @@ func (r *Resource) getCurrentTenantClusters(ctx context.Context) ([]tenantCluste
 // Returns a list of AWS clusters according to the awscluster resource.
 func (r *Resource) getCurrentAWSClusters(ctx context.Context) ([]tenantCluster, error) {
 	awsClusters, err := r.listPartialObjectMetadata(ctx, metav1.GroupVersionKind{
-		Group:   "cluster.x-k8s.io",
+		Group:   "infrastructure.cluster.x-k8s.io",
 		Version: "v1alpha2",
 		Kind:    "AWSCluster",
 	}, "default")
@@ -92,7 +92,7 @@ func (r *Resource) getCurrentAWSClusters(ctx context.Context) ([]tenantCluster, 
 // Returns a list of Azure clusters according to the azurecluster resource.
 func (r *Resource) getCurrentAzureClusters(ctx context.Context) ([]tenantCluster, error) {
 	azureClusters, err := r.listPartialObjectMetadata(ctx, metav1.GroupVersionKind{
-		Group:   "cluster.x-k8s.io",
+		Group:   "infrastructure.cluster.x-k8s.io.cluster.x-k8s.io",
 		Version: "v1alpha3",
 		Kind:    "AzureCluster",
 	}, "default")

--- a/service/controller/release/resource/status/cluster.go
+++ b/service/controller/release/resource/status/cluster.go
@@ -92,7 +92,7 @@ func (r *Resource) getCurrentAWSClusters(ctx context.Context) ([]tenantCluster, 
 // Returns a list of Azure clusters according to the azurecluster resource.
 func (r *Resource) getCurrentAzureClusters(ctx context.Context) ([]tenantCluster, error) {
 	azureClusters, err := r.listPartialObjectMetadata(ctx, metav1.GroupVersionKind{
-		Group:   "infrastructure.cluster.x-k8s.io.cluster.x-k8s.io",
+		Group:   "infrastructure.cluster.x-k8s.io",
 		Version: "v1alpha3",
 		Kind:    "AzureCluster",
 	}, "default")

--- a/service/controller/release/resource/status/create.go
+++ b/service/controller/release/resource/status/create.go
@@ -62,16 +62,16 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		// Get two sets of just deduplicated versions
 		releaseVersions, operatorVersions := consolidateClusterVersions(tenantClusters)
 		// Check the set of release versions and keep this release if it is used.
-		r.logger.Log("level", "debug", "message", fmt.Sprintf("checking release %s", release.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking release %s", release.Name))
 		if releaseVersions[strings.TrimPrefix(release.Name, "v")] { // The release name has a leading `v`
-			r.logger.Log("level", "debug", "message", fmt.Sprintf("keeping release %s because it is explicitly used", release.Name))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("keeping release %s because it is explicitly used", release.Name))
 			releaseInUse = true
 		} else {
 			for _, o := range key.GetProviderOperators() {
 				operatorVersion := getOperatorVersionInRelease(o, release)
 				// Check the set of operator versions and keep this release if its operator version is used.
 				if operatorVersion != "" && operatorVersions[o][operatorVersion] {
-					r.logger.Log("level", "debug", "message", fmt.Sprintf("keeping release %s because a cluster using its operator version (%s) is present", release.Name, operatorVersion))
+					r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("keeping release %s because a cluster using its operator version (%s) is present", release.Name, operatorVersion))
 					releaseInUse = true
 				}
 			}


### PR DESCRIPTION
This change breaks release-operator in the sense that it can't find workload clusters anymore.

## Checklist

- [X] Update changelog in CHANGELOG.md.
