### PR TITLE
Add george preview release state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a 'preview' release state
+
 ## [3.0.1] - 2021-12-09
 
 ### Fixed

--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -18,6 +18,7 @@ var (
 	StateActive     ReleaseState = "active"
 	StateDeprecated ReleaseState = "deprecated"
 	StateWIP        ReleaseState = "wip"
+	StatePreview    ReleaseState = "preview"
 )
 
 func (r ReleaseState) String() string {
@@ -86,7 +87,7 @@ type ReleaseSpec struct {
 	EndOfLifeDate *metav1.Time `json:"endOfLifeDate,omitempty"`
 
 	// +kubebuilder:validation:Type=string
-	// +kubebuilder:validation:Pattern=`^(active|deprecated|wip)$`
+	// +kubebuilder:validation:Pattern=`^(active|deprecated|wip|preview)$`
 	// State indicates the availability of the release: deprecated, active, or wip.
 	State ReleaseState `json:"state"`
 

--- a/config/crd/release.giantswarm.io_releases.yaml
+++ b/config/crd/release.giantswarm.io_releases.yaml
@@ -137,7 +137,7 @@ spec:
               state:
                 description: 'State indicates the availability of the release: deprecated,
                   active, or wip.'
-                pattern: ^(active|deprecated|wip)$
+                pattern: ^(active|deprecated|wip|preview)$
                 type: string
             required:
             - apps


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.

The release preview state added in this PR https://github.com/giantswarm/apiextensions/pull/836 but got left behind when dropping `apiextensions` as a dependency
