### PR TITLE
- Changed module version to v3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Changed module version to v3 as released version is v3.
+
 ## [3.1.0] - 2022-01-07
 
 ### Added

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -3,7 +3,7 @@ package flag
 import (
 	"github.com/giantswarm/microkit/flag"
 
-	"github.com/giantswarm/release-operator/v2/flag/service"
+	"github.com/giantswarm/release-operator/v3/flag/service"
 )
 
 // Flag provides data structure for service command line flags.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/release-operator/v2
+module github.com/giantswarm/release-operator/v3
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -7,10 +7,10 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/viper"
 
-	"github.com/giantswarm/release-operator/v2/flag"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
-	"github.com/giantswarm/release-operator/v2/server"
-	"github.com/giantswarm/release-operator/v2/service"
+	"github.com/giantswarm/release-operator/v3/flag"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
+	"github.com/giantswarm/release-operator/v3/server"
+	"github.com/giantswarm/release-operator/v3/service"
 )
 
 var (

--- a/server/endpoint/endpoint.go
+++ b/server/endpoint/endpoint.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/giantswarm/release-operator/v2/service"
+	"github.com/giantswarm/release-operator/v3/service"
 )
 
 type Config struct {

--- a/server/server.go
+++ b/server/server.go
@@ -10,9 +10,9 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/spf13/viper"
 
-	"github.com/giantswarm/release-operator/v2/pkg/project"
-	"github.com/giantswarm/release-operator/v2/server/endpoint"
-	"github.com/giantswarm/release-operator/v2/service"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
+	"github.com/giantswarm/release-operator/v3/server/endpoint"
+	"github.com/giantswarm/release-operator/v3/service"
 )
 
 // Config represents the configuration used to construct server object.

--- a/service/collector/release.go
+++ b/service/collector/release.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/giantswarm/release-operator/v2/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/api/v1alpha1"
 )
 
 const (

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -9,8 +9,8 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	releasev1alpha1 "github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
 )
 
 const (

--- a/service/controller/key/key_test.go
+++ b/service/controller/key/key_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	releasev1alpha1 "github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
 )
 
 var testComponents = []releasev1alpha1.ReleaseSpecComponent{

--- a/service/controller/release.go
+++ b/service/controller/release.go
@@ -8,9 +8,9 @@ import (
 	"github.com/giantswarm/operatorkit/v6/pkg/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
-	"github.com/giantswarm/release-operator/v2/service/controller/release"
+	"github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
+	"github.com/giantswarm/release-operator/v3/service/controller/release"
 )
 
 var (

--- a/service/controller/release/resource/apps/resource.go
+++ b/service/controller/release/resource/apps/resource.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	releasev1alpha1 "github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
-	"github.com/giantswarm/release-operator/v2/service/controller/key"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
+	"github.com/giantswarm/release-operator/v3/service/controller/key"
 )
 
 const (

--- a/service/controller/release/resource/apps/resource_test.go
+++ b/service/controller/release/resource/apps/resource_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	releasev1alpha1 "github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/service/controller/key"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/service/controller/key"
 )
 
 var testComponents = []releasev1alpha1.ReleaseSpecComponent{

--- a/service/controller/release/resource/configs/resource.go
+++ b/service/controller/release/resource/configs/resource.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	releasev1alpha1 "github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
-	"github.com/giantswarm/release-operator/v2/service/controller/key"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
+	"github.com/giantswarm/release-operator/v3/service/controller/key"
 )
 
 const (

--- a/service/controller/release/resource/configs/resource_test.go
+++ b/service/controller/release/resource/configs/resource_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	releasev1alpha1 "github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
-	"github.com/giantswarm/release-operator/v2/service/controller/key"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
+	"github.com/giantswarm/release-operator/v3/service/controller/key"
 )
 
 var testComponents = []releasev1alpha1.ReleaseSpecComponent{

--- a/service/controller/release/resource/status/cluster.go
+++ b/service/controller/release/resource/status/cluster.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/release-operator/v2/service/controller/key"
+	"github.com/giantswarm/release-operator/v3/service/controller/key"
 )
 
 type tenantCluster struct {

--- a/service/controller/release/resource/status/create.go
+++ b/service/controller/release/resource/status/create.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	releasev1alpha1 "github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
-	"github.com/giantswarm/release-operator/v2/service/controller/key"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
+	"github.com/giantswarm/release-operator/v3/service/controller/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {

--- a/service/controller/release/resource/status/kvm.go
+++ b/service/controller/release/resource/status/kvm.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/release-operator/v2/service/controller/key"
+	"github.com/giantswarm/release-operator/v3/service/controller/key"
 )
 
 const (

--- a/service/controller/release/resource_set.go
+++ b/service/controller/release/resource_set.go
@@ -8,9 +8,9 @@ import (
 	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/v6/pkg/resource/wrapper/retryresource"
 
-	"github.com/giantswarm/release-operator/v2/service/controller/release/resource/apps"
-	"github.com/giantswarm/release-operator/v2/service/controller/release/resource/configs"
-	"github.com/giantswarm/release-operator/v2/service/controller/release/resource/status"
+	"github.com/giantswarm/release-operator/v3/service/controller/release/resource/apps"
+	"github.com/giantswarm/release-operator/v3/service/controller/release/resource/configs"
+	"github.com/giantswarm/release-operator/v3/service/controller/release/resource/status"
 )
 
 type ResourceSetConfig struct {

--- a/service/service.go
+++ b/service/service.go
@@ -15,11 +15,11 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/client-go/rest"
 
-	releasev1alpha1 "github.com/giantswarm/release-operator/v2/api/v1alpha1"
-	"github.com/giantswarm/release-operator/v2/flag"
-	"github.com/giantswarm/release-operator/v2/pkg/project"
-	"github.com/giantswarm/release-operator/v2/service/collector"
-	"github.com/giantswarm/release-operator/v2/service/controller"
+	releasev1alpha1 "github.com/giantswarm/release-operator/v3/api/v1alpha1"
+	"github.com/giantswarm/release-operator/v3/flag"
+	"github.com/giantswarm/release-operator/v3/pkg/project"
+	"github.com/giantswarm/release-operator/v3/service/collector"
+	"github.com/giantswarm/release-operator/v3/service/controller"
 )
 
 // Config represents the configuration used to create a new service.


### PR DESCRIPTION
The released veresion of this project is 3.1.0, but go.mod still contained v2.
This made impossible to include this project as a dependency in another project.

this PR fixes this error.

## Checklist

- [x] Update changelog in CHANGELOG.md.
