### PR TITLE
Fix v3 for package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/release-operator/v2
+module github.com/giantswarm/release-operator/v3
 
 go 1.17
 


### PR DESCRIPTION
We updated to v3 a long time ago but forgot to update it modules. because we moved release apis from apiextensions now to release-operator we need to fix that.
