### PR TITLE
Add global.podSecurityStandards.enforced value for PSS migration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add global.podSecurityStandards.enforced value for PSS migration.
+
 ## [4.1.1] - 2023-12-06
 
-### Changelog
+### Changed
 
 - Configure gsoci.azurecr.io as the registry to use by default
 

--- a/helm/release-operator/templates/psp.yaml
+++ b/helm/release-operator/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -31,3 +32,4 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+{{- end }}

--- a/helm/release-operator/templates/rbac.yaml
+++ b/helm/release-operator/templates/rbac.yaml
@@ -98,6 +98,7 @@ roleRef:
   name: {{ include "resource.default.name" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
+{{- if not .Values.global.podSecurityStandards.enforced }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -128,3 +129,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/release-operator/values.schema.json
+++ b/helm/release-operator/values.schema.json
@@ -2,6 +2,19 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/helm/release-operator/values.yaml
+++ b/helm/release-operator/values.yaml
@@ -34,3 +34,7 @@ securityContext:
   capabilities:
     drop:
     - ALL
+
+global:
+  podSecurityStandards:
+    enforced: false


### PR DESCRIPTION
Needed to bump vintage MCs to 1.25

## Checklist

- [x] Update changelog in CHANGELOG.md.
