### PR TITLE
Update docs links

### DIFF
--- a/api/v1alpha1/release_types.go
+++ b/api/v1alpha1/release_types.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	kindRelease              = "Release"
-	releaseDocumentationLink = "https://docs.giantswarm.io/ui-api/management-api/crd/releases.release.giantswarm.io/"
+	releaseDocumentationLink = "https://docs.giantswarm.io/reference/platform-api/crd/releases.release.giantswarm.io/"
 	releaseNotesLink         = "https://docs.giantswarm.io/changes/workload-cluster-releases-aws/releases/aws-v11.2.0/"
 )
 

--- a/docs/cr/release.giantswarm.io_v1alpha1_release.yaml
+++ b/docs/cr/release.giantswarm.io_v1alpha1_release.yaml
@@ -2,7 +2,7 @@ apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
   annotations:
-    giantswarm.io/docs: https://docs.giantswarm.io/ui-api/management-api/crd/releases.release.giantswarm.io/
+    giantswarm.io/docs: https://docs.giantswarm.io/reference/platform-api/crd/releases.release.giantswarm.io/
     giantswarm.io/release-notes: https://docs.giantswarm.io/changes/workload-cluster-releases-aws/releases/aws-v11.2.0/
   creationTimestamp: null
   name: v11.2.0


### PR DESCRIPTION
### Summary

Documentation for the `Release` CRD was moved, update links.

**NOTE:** I'm updating the links in the documentation and proposed the change here, assuming this component should still be updated (it isn't marked deprecated).
