### PR TITLE
Migrate to App Build Suite (ABS)

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,0 +1,7 @@
+replace-chart-version-with-git: true
+replace-app-version-with-git: true
+generate-metadata: true
+chart-dir: ./helm/release-operator
+destination: build
+catalog-base-url: https://giantswarm.github.io/control-plane-test-catalog/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,28 @@ workflows:
   version: 2
   build_e2e:
     jobs:
+      - architect/go-build:
+          name: go-build-release-operator
+          binary: release-operator
+          filters:
+            # Trigger the job also on git tag.
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
+          requires:
+            - go-build-release-operator
+          filters:
+            # Trigger the job also on git tag.
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - main
+                - master
+
       - architect/push-to-app-catalog:
           context: architect
           executor: app-build-suite
@@ -14,6 +36,8 @@ workflows:
           app_catalog: control-plane-catalog
           app_catalog_test: control-plane-test-catalog
           chart: release-operator
+          requires:
+            - push-to-registries
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,36 +7,13 @@ workflows:
   version: 2
   build_e2e:
     jobs:
-      - architect/go-build:
-          name: go-build-release-operator
-          binary: release-operator
-          filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-registries:
-          context: architect
-          name: push-to-registries
-          requires:
-            - go-build-release-operator
-          filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-            branches:
-              ignore:
-                - main
-                - master
-
       - architect/push-to-app-catalog:
           context: architect
+          executor: app-build-suite
           name: push-release-operator-to-control-plane-app-catalog
           app_catalog: control-plane-catalog
           app_catalog_test: control-plane-test-catalog
           chart: release-operator
-          requires:
-            - push-to-registries
           filters:
             tags:
               only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Migrate to App Build Suite (ABS) for building and publishing Helm charts.
 - Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
 
 ## [4.2.1] - 2025-06-24

--- a/helm/release-operator/Chart.yaml
+++ b/helm/release-operator/Chart.yaml
@@ -2,7 +2,9 @@ apiVersion: v2
 name: release-operator
 description: Helm chart for release-operator.
 home: https://github.com/giantswarm/release-operator
-version: '[[ .Version ]]'
-appVersion: '[[ .AppVersion ]]'
+version: 4.2.2-dev
+appVersion: 4.2.2-dev
+icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
 annotations:
+  application.giantswarm.io/team: honeybadger
   io.giantswarm.application.team: honeybadger

--- a/helm/release-operator/templates/_helpers.tpl
+++ b/helm/release-operator/templates/_helpers.tpl
@@ -20,11 +20,21 @@ Common labels
 {{ include "labels.selector" . }}
 app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
-application.giantswarm.io/branch: {{ .Values.project.branch | quote }}
-application.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
+{{- end -}}
+
+{{/*
+Image tag helper
+*/}}
+{{- define "image.tag" -}}
+{{- if .Values.image.tag -}}
+{{- .Values.image.tag -}}
+{{- else -}}
+{{- .Chart.AppVersion -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/release-operator/templates/deployment.yaml
+++ b/helm/release-operator/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           {{- end }}
       containers:
       - name: release-operator
-        image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ include "image.tag" . }}"
         args:
         - daemon
         - --config.dirs=/var/run/release-operator/configmap/

--- a/helm/release-operator/templates/deployment.yaml
+++ b/helm/release-operator/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
         - daemon
         - --config.dirs=/var/run/release-operator/configmap/
         - --config.files=config
+        ports:
+        - name: http
+          containerPort: 8000
+          protocol: TCP
         volumeMounts:
         - name: {{ include "resource.configMap.name" . }}
           mountPath: /var/run/release-operator/configmap/

--- a/helm/release-operator/values.schema.json
+++ b/helm/release-operator/values.schema.json
@@ -64,17 +64,6 @@
                 }
             }
         },
-        "project": {
-            "type": "object",
-            "properties": {
-                "branch": {
-                    "type": "string"
-                },
-                "commit": {
-                    "type": "string"
-                }
-            }
-        },
         "registry": {
             "type": "object",
             "properties": {
@@ -125,6 +114,10 @@
                             "default": ["ALL"]
                         }
                     }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "default": true
                 }
             }
         }

--- a/helm/release-operator/values.yaml
+++ b/helm/release-operator/values.yaml
@@ -1,10 +1,6 @@
 image:
   name: "giantswarm/release-operator"
-  tag: "[[ .Version ]]"
-
-project:
-  branch: "[[ .Branch ]]"
-  commit: "[[ .SHA ]]"
+  tag: ""
 
 pod:
   user:
@@ -34,6 +30,7 @@ securityContext:
   capabilities:
     drop:
     - ALL
+  readOnlyRootFilesystem: true
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
This PR migrates the repository to use the App Build Suite (ABS) for building and publishing Helm charts.

## Changes

- Updated CircleCI config to use `app-build-suite` executor
- Removed `go-build` and `push-to-registries` jobs (handled by ABS)
- Added `.abs/main.yaml` configuration
- Updated `Chart.yaml`:
  - Added `application.giantswarm.io/team` annotation (keeping `io.giantswarm.application.team` for OCI compliance)
  - Added `icon`
  - Updated version to dev version
- Updated `_helpers.tpl`:
  - Removed branch/commit labels
  - Added team label reading from Chart annotation
  - Added `image.tag` helper function
- Updated `values.yaml`:
  - Removed `project.branch` and `project.commit`
  - Cleared `image.tag` placeholder
  - Added `readOnlyRootFilesystem: true`
- Updated `values.schema.json`:
  - Removed `project` section
  - Added `readOnlyRootFilesystem`
- Updated `deployment.yaml` to use `image.tag` helper
- Updated `CHANGELOG.md`

Related: https://github.com/giantswarm/giantswarm/issues/35210